### PR TITLE
Added restart for Homebrew Apache installed without root privileges

### DIFF
--- a/sphp
+++ b/sphp
@@ -36,6 +36,11 @@ if [ $? -eq 0 ]; then
 		sudo pkill -9 -f /usr/local/Cellar/*/httpd
 		sudo /usr/local/bin/apachectl -k restart > /dev/null 2>&1
 	fi
+	pgrep -x httpd 2> /dev/null > /dev/null
+	if [ $? -eq 0 ]; then
+		echo "Restarting non-root homebrew Apache..."
+		httpd -k restart > /dev/null 2>&1
+	fi
 
 	echo "Done."
 else


### PR DESCRIPTION
This change adds a restart for Apache installed without root rights (according to https://gist.github.com/alefi87/bc778a7ca918d27821a1)