### PR TITLE
Fix: suppress errors when checking versions

### DIFF
--- a/sphp
+++ b/sphp
@@ -5,11 +5,11 @@ if [ $# -ne 1 ]; then
 	exit 1
 fi
 
-currentversion="`php -r \"echo str_replace('.', '', substr(phpversion(), 0, 3));\"`"
+currentversion="`php -r \"error_reporting(0); echo str_replace('.', '', substr(phpversion(), 0, 3));\"`"
 newversion="$1"
 
-shortOld="`php -r \"echo substr(phpversion(), 0, 1);\"`"
-shortNew="`php -r \"echo substr('$1', 0, 1);\"`"
+shortOld="`php -r \"error_reporting(0); echo substr(phpversion(), 0, 1);\"`"
+shortNew="`php -r \"error_reporting(0); echo substr('$1', 0, 1);\"`"
 
 brew list php$newversion 2> /dev/null > /dev/null
 


### PR DESCRIPTION
turn off all errors when running a command with `php -r`
hides deprecated memcached ini warnings when running php7

fix your `ext-memcached.ini`:
> `memcached.sess_lock_wait` and `memcached.sess_lock_max_wait` are deprecated. 
update to the correct flags (or comment them out to use defaults) - new flags: 
> `memcached.sess_lock_wait_min`, `memcached.sess_lock_wait_max` and `memcached.sess_lock_retries`