### PR TITLE
check minor version in hhtp.conf

### DIFF
--- a/sphp
+++ b/sphp
@@ -54,7 +54,12 @@ if [ $? -eq 0 ]; then
 	echo "Fixing LoadModule..."
 	apacheConf=`httpd -V | grep -i server_config_file | cut -d '"' -f 2`
 	sudo sed -i -e "/LoadModule php${majorOld}_module/s/^#*/#/" $apacheConf
-	sudo sed -i -e "/LoadModule php${majorNew}_module \/usr\/local\/opt\/php${newversion}/s/^#//" $apacheConf
+	if grep "LoadModule php${majorNew}_module .*php${newversion}" $apacheConf > /dev/null
+	then 
+		sudo sed -i -e "/LoadModule php${majorNew}_module .*php${newversion}/s/^#//" $apacheConf
+	else
+		sudo sed -i -e "/LoadModule php${majorNew}_module/s/^#//" $apacheConf
+	fi
 
 	echo "Updating version file..."
 


### PR DESCRIPTION
Check if minor version is present in http.conf

Works well with distinct paths:

LoadModule php5_module libexec/apache2/libphp5.so
#LoadModule php7_module libexec/apache2/libphp7.so

LoadModule php5_module        /usr/local/Cellar/php56/5.6.27_4/libexec/apache2/libphp5.so
#LoadModule php7_module        /usr/local/Cellar/php70/7.0.13_6/libexec/apache2/libphp7.so
#LoadModule php7_module        /usr/local/Cellar/php71/7.1.0-rc.6_10/libexec/apache2/libphp7.so

LoadModule php5_module /usr/local/opt/php56/libexec/apache2/libphp5.so
#LoadModule php7_module /usr/local/opt/php70/libexec/apache2/libphp7.so
#LoadModule php7_module /usr/local/opt/php71/libexec/apache2/libphp7.so